### PR TITLE
Update ugly.rkt

### DIFF
--- a/ugly.rkt
+++ b/ugly.rkt
@@ -17,8 +17,8 @@
        ["'" (token 'QUOTE 'quote)]
        ["(" (token 'LPAREN)] [")" (token 'RPAREN)]
        ["/" (token 'SLASH)] ["." (token 'DOT)] ["," (token 'COMMA)]
-       [whitespace (ugly-lexer ip)]
-       [(from/to "%" "\n") (ugly-lexer ip)]
+       [whitespace (token 'WS #:skip? #t)]
+       [(from/to "%" "\n") (token 'COMMENT #:skip? #t)]
        [(from/to "\"" "\"") (token 'STRING (trim-ends "\"" lexeme "\""))]
        [(:+ alphabetic) (token 'ID (string->symbol lexeme))]
        [(eof) (void)]))


### PR DESCRIPTION
If you call `ugly-lexer` recursively with source positions activated, you will end up with tokens wrapped in multiple layers of positions. Easier to make a `#:skip? #t` token.

PS If you’re using `lexer` from `brag/support`, you can use `lexer-srcloc` instead of `lexer-src-pos` (which supports contemporary `srcloc` structures) and if you like, omit the `eof` rule in the parser.